### PR TITLE
Correction to Depth Annotation (Depth Scaling Factor)

### DIFF
--- a/new_readme.md
+++ b/new_readme.md
@@ -79,3 +79,7 @@ The code for MPI-INF-3DHP and 3DPW dataset preparing is adpoted from:
 The ./lib folder holds the code from VIBE repo, for the 3DPW and MPI-INF-3DHP dataset dataloader.
 
 For LSP-Extended Dataloader referenced: https://github.com/bmartacho/UniPose/blob/master/utils/lsp_lspet_data.py
+
+For calcualting depth scaling factor between gt_3d and pts (used by annotation file of src/lib/datasets/h36m.py), referenced: 
+- https://github.com/JimmySuen/integral-human-pose/blob/master/pytorch_projects/common_pytorch/dataset/hm36_eccv_challenge.py#L72-L76
+- https://github.com/JimmySuen/integral-human-pose/blob/master/common/utility/utils.py#L70

--- a/src/lib/datasets/mpii3d.py
+++ b/src/lib/datasets/mpii3d.py
@@ -19,6 +19,7 @@ from utils.image import flip, shuffle_lr
 from utils.image import draw_gaussian, adjust_aspect_ratio
 from utils.image import get_affine_transform, affine_transform
 from utils.image import transform_preds
+from utils.image import compute_similarity_transform
 
 class MPII3D(data.Dataset):
   def __init__(self, opt, split):
@@ -74,6 +75,15 @@ class MPII3D(data.Dataset):
     pts = np.array(ann['joints3D_image'], np.float32) # joint_3d_image is [image_coord_x, image_coord_y, depth-root depth], in mpii format (16 joints)
     c = np.array([ann['bbox'][0], ann['bbox'][1]], dtype=np.float32) # c_x, c_y for bbox
     s = max(ann['bbox'][2], ann['bbox'][3]) # w, h for bbox
+        
+    # to get the correct "depth-root" value for pts, using similarity transform to get depth_scale
+    # and then set pts[2] = gt_3d[2] * depth_scale
+    # Refence: https://github.com/JimmySuen/integral-human-pose/blob/master/pytorch_projects/common_pytorch/dataset/hm36_eccv_challenge.py#L72-L76
+    from_pose = gt_3d[:,0:2][self.h36m_to_mpii]
+    target_pose = pts[:,0:2]
+    _, _, _, depth_scale, _ = compute_similarity_transform(target_pose, from_pose, compute_optimal_scale=True)
+    pts[:,2] = gt_3d[:,2][self.h36m_to_mpii] * depth_scale
+    
     return gt_3d, pts, c, s
       
   def __getitem__(self, index):

--- a/src/lib/utils/image.py
+++ b/src/lib/utils/image.py
@@ -146,3 +146,64 @@ def adjust_aspect_ratio(s, aspect_ratio, fit_short_side=False):
     else:
       w = h * aspect_ratio
   return np.array([w, h])
+
+def compute_similarity_transform(X, Y, compute_optimal_scale=False):
+    """
+    Reference: https://github.com/JimmySuen/integral-human-pose/blob/master/common/utility/utils.py#L70
+
+    A port of MATLAB's `procrustes` function to Numpy.
+    Adapted from http://stackoverflow.com/a/18927641/1884420
+    Args
+        X: array NxM of targets, with N number of points and M point dimensionality
+        Y: array NxM of inputs
+        compute_optimal_scale: whether we compute optimal scale or force it to be 1
+    Returns:
+        d: squared error after transformation
+        Z: transformed Y
+        T: computed rotation
+        b: scaling
+        c: translation
+    """
+    muX = X.mean(0)
+    muY = Y.mean(0)
+
+    X0 = X - muX
+    Y0 = Y - muY
+
+    ssX = (X0 ** 2.).sum()
+    ssY = (Y0 ** 2.).sum()
+
+    # centred Frobenius norm
+    normX = np.sqrt(ssX)
+    normY = np.sqrt(ssY)
+
+    # scale to equal (unit) norm
+    X0 = X0 / normX
+    Y0 = Y0 / normY
+
+    # optimum rotation matrix of Y
+    A = np.dot(X0.T, Y0)
+    U, s, Vt = np.linalg.svd(A, full_matrices=False)
+    V = Vt.T
+    T = np.dot(V, U.T)
+
+    # Make sure we have a rotation
+    detT = np.linalg.det(T)
+    V[:, -1] *= np.sign(detT)
+    s[-1] *= np.sign(detT)
+    T = np.dot(V, U.T)
+
+    traceTA = s.sum()
+
+    if compute_optimal_scale:  # Compute optimum scaling of Y.
+        b = traceTA * normX / normY
+        d = 1 - traceTA ** 2
+        Z = normX * traceTA * np.dot(Y0, T) + muX
+    else:  # If no scaling allowed
+        b = 1
+        d = 1 + ssY / ssX - 2 * traceTA * normY / normX
+        Z = normY * np.dot(Y0, T) + muX
+
+    c = muX - b * np.dot(muY, T)
+
+    return d, Z, T, b, c

--- a/src/main.py
+++ b/src/main.py
@@ -36,7 +36,7 @@ dataset_factory = {
   'fusion_3d': Fusion3D,
   'H36M': H36M,
   'MPII3D': MPII3D,
-  'ThreeDPW': ThreeDPW,
+  '3DPW': ThreeDPW,
   'OcclusionPerson': OcclusionPerson,
 }
 


### PR DESCRIPTION
For calculating depth scaling factor between gt_3d and pts (used by annotation file of src/lib/datasets/h36m.py), 
I referenced: 
- https://github.com/JimmySuen/integral-human-pose/blob/master/pytorch_projects/common_pytorch/dataset/hm36_eccv_challenge.py#L72-L76
- https://github.com/JimmySuen/integral-human-pose/blob/master/common/utility/utils.py#L70

```
# to get the correct "depth-root" value for pts, using similarity transform to get depth_scale
# and then set pts[2] = gt_3d[2] * depth_scale
# Refence: https://github.com/JimmySuen/integral-human-pose/blob/master/pytorch_projects/common_pytorch/dataset/hm36_eccv_challenge.py#L72-L76
from_pose = gt_3d[:,0:2][self.h36m_to_mpii]
target_pose = pts[:,0:2]
_, _, _, depth_scale, _ = compute_similarity_transform(target_pose, from_pose, compute_optimal_scale=True)
pts[:,2] = gt_3d[:,2][self.h36m_to_mpii] * depth_scale
```

After this fix to the depth annotation, the high MPJPE issue happened on 3D datasets (except from H36M) is resolved for Occulusion Person, and MPII3D.